### PR TITLE
linagora/customers#48: Serve index.html from static content with dev server

### DIFF
--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -91,7 +91,15 @@ module.exports = {
   ],
   devServer: {
     contentBase: [path.resolve(__dirname, 'dist'), path.resolve(__dirname, 'node_modules', 'esn-frontend-login', 'dist')],
+    // contentBasePublicPath and writeToDisk are needed because webpack base path is 'assets' subfolder
+    // So index.html needs to be accessed explicitly from root 'dist' folder
     contentBasePublicPath: [BASE_HREF + 'index.html', '/login'],
+    // and index.html needs to be copied explicitly to root 'dist' folder
+    writeToDisk: filePath => {
+      if (filePath.endsWith('index.html')) {
+        return (filePath);
+      }
+    },
     compress: true,
     host: '0.0.0.0',
     disableHostCheck: true,


### PR DESCRIPTION
This fixes the dev server mode creating the dist/index.html so it is served by dev server ContentBase.